### PR TITLE
refactor: 🚚 dockerhub image naming

### DIFF
--- a/.github/workflows/relayer.yml
+++ b/.github/workflows/relayer.yml
@@ -122,4 +122,4 @@ jobs:
         with:
           context: ./relayer
           push: true
-          tags: moonsonglabs/snowbridge-relayer:${{ steps.docker_tag_value.outputs.value }}
+          tags: moonsonglabs/snowbridge-relay:${{ steps.docker_tag_value.outputs.value }}


### PR DESCRIPTION
This small PR updates the name of the relayer docker image published on DockerHub to keep it in line with the naming convention upstream