### PR TITLE
fix: :bug: update Docker build platform

### DIFF
--- a/relayer/build-local-docker.sh
+++ b/relayer/build-local-docker.sh
@@ -5,7 +5,7 @@ source ../web/packages/test/scripts/set-env.sh
 
 build_image()
 {
-    docker build -f Dockerfile -t snowbridge-relay:local .
+    docker build --platform linux/amd64 -f Dockerfile -t snowbridge-relay:local .
 }
 
 if [ -z "${from_start_services:-}" ]; then


### PR DESCRIPTION
This PR updates the platform used when building the relayer image with Docker to match what's expected on DataHaven (`linux/amd64`).