### PR TITLE
fix: :bug: add ca-certificates to relay Docker image

### DIFF
--- a/relayer/Dockerfile
+++ b/relayer/Dockerfile
@@ -4,6 +4,9 @@ ADD . .
 RUN go build -v -o build/snowbridge-relay main.go
 
 FROM ubuntu:22.04
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 COPY --from=0 /opt/relayer/build/snowbridge-relay /usr/local/bin/
 VOLUME ["/config"]
 ENTRYPOINT ["/usr/local/bin/snowbridge-relay"]


### PR DESCRIPTION
## Summary
- Install `ca-certificates` package in the relay Docker image to enable TLS connections to secure `wss://` endpoints
- Without CA certificates, the relay fails to connect with `x509: certificate signed by unknown authority` errors
